### PR TITLE
Add caching support for persist Redis

### DIFF
--- a/ballerina/Dependencies.toml
+++ b/ballerina/Dependencies.toml
@@ -81,6 +81,18 @@ modules = [
 
 [[package]]
 org = "ballerina"
+name = "lang.runtime"
+version = "0.0.0"
+scope = "testOnly"
+dependencies = [
+	{org = "ballerina", name = "jballerina.java"}
+]
+modules = [
+	{org = "ballerina", packageName = "lang.runtime", moduleName = "lang.runtime"}
+]
+
+[[package]]
+org = "ballerina"
 name = "lang.value"
 version = "0.0.0"
 dependencies = [
@@ -152,6 +164,7 @@ version = "0.1.0"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"},
 	{org = "ballerina", name = "lang.regexp"},
+	{org = "ballerina", name = "lang.runtime"},
 	{org = "ballerina", name = "log"},
 	{org = "ballerina", name = "persist"},
 	{org = "ballerina", name = "test"},

--- a/ballerina/Module.md
+++ b/ballerina/Module.md
@@ -25,7 +25,7 @@ Since Redis is not the default datastore for `bal persist` you need to explicitl
 1. Initialize `bal persist` using the following command,
 
     ```
-    $ bal persist init --datastore redis
+    $ bal persist init
     ```
 
 2. Generate the persist client using the following command,

--- a/ballerina/Package.md
+++ b/ballerina/Package.md
@@ -25,7 +25,7 @@ Since Redis is not the default datastore for `bal persist` you need to explicitl
 1. Initialize `bal persist` using the following command,
 
     ```
-    $ bal persist init --datastore redis
+    $ bal persist init
     ```
 
 2. Generate the persist client using the following command,

--- a/ballerina/build.gradle
+++ b/ballerina/build.gradle
@@ -207,29 +207,64 @@ task startRedisTestDockerContainer(type: Exec) {
     }
 }
 
-task stopRedisTestDockerContainer() {
-    doLast {
-        if (!Os.isFamily(Os.FAMILY_WINDOWS)) {
-            try {
-                def stdOut = new ByteArrayOutputStream()
-                exec {
-                    commandLine 'sh', '-c', "docker stop ballerina-persist-redis"
-                    standardOutput = stdOut
-                }
-            } catch (all) {
-                println("Process can safely ignore stopRedisTestDockerContainer task")
+task startRedisCacheTestDockerContainer(type: Exec) {
+    if (!Os.isFamily(Os.FAMILY_WINDOWS)) {
+        def standardOutput = new ByteArrayOutputStream()
+        commandLine 'sh', '-c',
+                "docker run --rm -d --name ballerina-persist-redis-cache -p 6378:6379 -d ballerina-persist-redis"
+        def healthCheck = 1;
+        def counter = 0;
+        doLast {
+            checkExecResult(executionResult, 'Error', standardOutput)
+            while (healthCheck != 0 && counter < 12) {
+                sleep(5 * 1000)
+                healthCheck = checkRedisTestDockerContainerStatus("ballerina-persist-redis-cache")
+                counter = counter + 1;
             }
-        } else {
-            try {
-                def stdOut = new ByteArrayOutputStream()
-                exec {
-                    commandLine 'cmd', '/c', "docker stop ballerina-persist-redis"
-                    standardOutput = stdOut
-                }
-            } catch (all) {
-                println("Process can safely ignore stopRedisTestDockerContainer task")
+            if (healthCheck != 0) {
+                throw new GradleException("Docker container 'ballerina-persist-redis-cache' health test exceeded timeout!")
             }
         }
+    } else {
+        def standardOutput = new ByteArrayOutputStream()
+        commandLine 'cmd', '/c',
+                "docker run --rm -d --name ballerina-persist-redis-cache -p 6378:6379 -d ballerina-persist-redis"
+        def healthCheck = 1;
+        def counter = 0;
+        doLast {
+            checkExecResult(executionResult, 'Error', standardOutput)
+            while (healthCheck != 0 && counter < 12) {
+                sleep(5 * 1000)
+                healthCheck = checkRedisTestDockerContainerStatus("ballerina-persist-redis-cache")
+                counter = counter + 1;
+            }
+            if (healthCheck != 0) {
+                throw new GradleException("Docker container 'ballerina-persist-redis-cache' health test exceeded timeout!")
+            }
+        }
+    }
+}
+
+task stopRedisTestDockerContainer() {
+    def stopDockerContainer = { containerName ->
+        def command
+        def osFamily = Os.isFamily(Os.FAMILY_WINDOWS) ? 'cmd' : 'sh'
+        def option = Os.isFamily(Os.FAMILY_WINDOWS) ? '/c' : '-c'
+        
+        try {
+            def stdOut = new ByteArrayOutputStream()
+            exec {
+                commandLine osFamily, option, "docker stop $containerName"
+                standardOutput = stdOut
+            }
+        } catch (all) {
+            println("Process can safely ignore stopping $containerName task")
+        }
+    }
+
+    doLast {
+        stopDockerContainer("ballerina-persist-redis")
+        stopDockerContainer("ballerina-persist-redis-cache")
     }
 }
 
@@ -255,6 +290,7 @@ task pullRedisDependency(type: Exec) {
 updateTomlFiles.dependsOn copyStdlibs
 pullRedisDependency.dependsOn unpackJballerinaTools
 startRedisTestDockerContainer.dependsOn createRedisTestDockerImage
+startRedisCacheTestDockerContainer.dependsOn createRedisTestDockerImage
 
 build.dependsOn "generatePomFileForMavenPublication"
 build.dependsOn ":${packageName}-native:build"
@@ -263,3 +299,4 @@ build.finalizedBy stopRedisTestDockerContainer
 
 test.dependsOn ":${packageName}-native:build"
 test.dependsOn startRedisTestDockerContainer
+test.dependsOn startRedisCacheTestDockerContainer

--- a/ballerina/redis_client.bal
+++ b/ballerina/redis_client.bal
@@ -30,18 +30,20 @@ public isolated client class RedisClient {
     private final map<FieldMetadata> & readonly fieldMetadata;
     private final string[] & readonly keyFields;
     private final map<RefMetadata> & readonly refMetadata;
+    private final int maxAge;
 
     # Initializes the `RedisClient`.
     #
     # + dbClient - The `redis:Client`, which is used to execute Redis database operations.
     # + metadata - Metadata of the entity
     # + return - A `persist:Error` if the client creation fails
-    public isolated function init(redis:Client dbClient, RedisMetadata & readonly metadata) returns persist:Error? {
+    public isolated function init(redis:Client dbClient, RedisMetadata & readonly metadata, int maxAge) returns persist:Error? {
         self.entityName = metadata.entityName;
         self.collectionName = metadata.collectionName;
         self.fieldMetadata = metadata.fieldMetadata;
         self.keyFields = metadata.keyFields;
         self.dbClient = dbClient;
+        self.maxAge = maxAge;
         (map<RefMetadata> & readonly)? refMetadata = metadata.refMetadata;
         if refMetadata is map<RefMetadata> & readonly {
             self.refMetadata = refMetadata;
@@ -171,9 +173,9 @@ public isolated client class RedisClient {
             }
 
             // Check for any relation field constraints
-            persist:Error? checkConstraints = self.checkRelationFieldConstraints(keySuffix, insertRecord);
-            if checkConstraints is persist:ConstraintViolationError {
-                return checkConstraints;
+            persist:Error? checkConstraintsResult = self.checkRelationFieldConstraints(keySuffix, insertRecord);
+            if checkConstraintsResult is persist:ConstraintViolationError {
+                return checkConstraintsResult;
             }
             string key = string `${self.collectionName}${keySuffix}`;
 
@@ -184,6 +186,7 @@ public isolated client class RedisClient {
                 result = self.dbClient->hMSet(key, insertRecord);
             }
             self.logQuery(HMSET, {key: key, "record": insertRecord.toJsonString()});
+            check self.setExpireIfCache(key, self.collectionName, key);
         } on fail persist:Error e {
             return e;
         }
@@ -206,8 +209,8 @@ public isolated client class RedisClient {
         do {
             // Check for references
             string[] allRefFields = [];
-            foreach RefMetadata refMedaData in self.refMetadata {
-                allRefFields.push(...refMedaData.joinFields);
+            foreach RefMetadata refMetaData in self.refMetadata {
+                allRefFields.push(...refMetaData.joinFields);
             }
 
             // Remove any references if exists
@@ -376,12 +379,10 @@ public isolated client class RedisClient {
         } on fail error e {
             return error persist:Error(e.message(), e);
         }
+        check self.setExpireIfCache(recordKey, self.collectionName, recordKey);
 
         // Add new association to the SET
         foreach RefMetadata refMetaData in self.refMetadata {
-            if !updatedEntities.hasKey(refMetaData.refCollection) {
-                continue;
-            }
             string[] joinFields = refMetaData.joinFields;
             string newRelatedRecordKey = refMetaData.refCollection;
             string prevRelatedRecordKey = refMetaData.refCollection;
@@ -393,6 +394,23 @@ public isolated client class RedisClient {
                 }
                 prevRelatedRecordKey += string `${KEY_SEPERATOR}${prevRecord[joinField].toString()}`;
             }
+
+            if !updatedEntities.hasKey(refMetaData.refCollection) {
+                string oldSetKey = string `${prevRelatedRecordKey}${KEY_SEPERATOR}${refMetaData.refMetaDataKey ?: ""}`;
+                // Update the ttl of unchanged associations
+                if self.isCache() {
+                    int|redis:Error ttlResult = self.dbClient->ttl(oldSetKey);
+                    if ttlResult is int && ttlResult <= 0 {
+                        int|error sAdd = self.dbClient->sAdd(oldSetKey, [recordKeySuffix.substring(1)]);
+                        if sAdd is error {
+                            return error persist:Error(sAdd.message(), sAdd);
+                        }
+                    }
+                }
+                check self.setExpireIfCache(oldSetKey, refMetaData.refCollection, prevRelatedRecordKey);
+                continue;
+            }
+
             // Attach to new association
             string newSetKey = string `${newRelatedRecordKey}${KEY_SEPERATOR}${refMetaData.refMetaDataKey ?: ""}`;
             int|error sAdd = self.dbClient->sAdd(newSetKey, [recordKeySuffix.substring(1)]);
@@ -400,6 +418,7 @@ public isolated client class RedisClient {
                 return error persist:Error(sAdd.message(), sAdd);
             }
             self.logQuery(SADD, {key: newSetKey, suffixes: [recordKeySuffix].toJsonString()});
+            check self.setExpireIfCache(newSetKey, refMetaData.refCollection, newRelatedRecordKey);
 
             // Detach from previous association
             string prevSetKey = string `${prevRelatedRecordKey}${KEY_SEPERATOR}${refMetaData.refMetaDataKey ?: ""}`;
@@ -409,6 +428,10 @@ public isolated client class RedisClient {
             }
             self.logQuery(SREM, {key: prevSetKey, suffixes: [recordKeySuffix].toJsonString()});
         }
+    }
+
+    private isolated function isCache() returns boolean {
+        return self.maxAge > 0;
     }
 
     # Retrieves all the associations of a given object
@@ -463,8 +486,22 @@ public isolated client class RedisClient {
             record {}[] associatedRecords = [];
             foreach string key in keySuffixes {
                 // Handling simple fields of the associated record
-                record {} valueToRecord = check self.queryRelationFieldsByKey(entity, cardinalityType,
-                string `${refMetaData.refCollection}${key}`, relationFields);
+                record {}|persist:Error valueToRecord = self.queryRelationFieldsByKey(entity, cardinalityType,
+                string `${refMetaData.refCollection}${KEY_SEPERATOR}${key}`, relationFields);
+
+                if valueToRecord is persist:Error {
+                    boolean isAssociationOwner = self.refMetadata[entity]?.joinFields != self.keyFields;
+                    if valueToRecord is persist:NotFoundError && !isAssociationOwner {
+                        string setKey = string `${self.getKeyFromObject('object)}${KEY_SEPERATOR}${refMetaData.fieldName}`;
+                        int|redis:Error sRem = self.dbClient->sRem(setKey, [key]);
+                        if sRem is redis:Error {
+                            return error persist:Error(sRem.message(), sRem);
+                        }
+                    } else if valueToRecord is persist:NotFoundError {
+                        return valueToRecord;
+                    }
+                    continue;
+                }
 
                 foreach string refField in valueToRecord.keys() {
                     if relationFields.indexOf(refField) is () {
@@ -524,8 +561,9 @@ public isolated client class RedisClient {
             string setKey = string `${self.getKeyFromObject('object)}${KEY_SEPERATOR}${refMetaData.fieldName}`;
             string[] keys = check self.dbClient->sMembers(setKey);
             self.logQuery(SMEMBERS, setKey);
+            check self.setExpireIfCache(setKey, refMetaData.refCollection, self.getKeyFromObject('object));
             return from string key in keys
-                select KEY_SEPERATOR + key;
+                select key;
         } else {
             map<any> recordWithRefFields = check self.dbClient->hMGet(self.getKeyFromObject('object),
             refMetaData.joinFields);
@@ -537,13 +575,27 @@ public isolated client class RedisClient {
             foreach string joinField in refMetaData.joinFields {
                 key += string `${KEY_SEPERATOR}${recordWithRefFields[joinField].toString()}`;
             }
-            return [key];
+            return [key.substring(1)];
         }
     }
 
     private isolated function querySimpleFieldsByKey(map<anydata> typeMap, string key, string[] fields)
-    returns record {|anydata...;|}|persist:Error {
+    returns record {|anydata...;|}|redis:Error|persist:Error {
         string[] simpleFields = self.getTargetSimpleFields(fields, typeMap);
+
+        // Add association fields if exists
+        string[] associationFields = [];
+        if self.isCache() {
+            foreach RefMetadata refMetaData in self.refMetadata {
+                foreach string joinField in refMetaData.joinFields {
+                    if self.fieldMetadata.hasKey(joinField) && self.keyFields.indexOf(joinField) is ()
+                    && simpleFields.indexOf(joinField) is () {
+                        associationFields.push(joinField);
+                        simpleFields.push(joinField);
+                    }
+                }
+            }
+        }
 
         do {
             // Retrieve the record
@@ -552,6 +604,30 @@ public isolated client class RedisClient {
             if self.isNoRecordFound(value) {
                 return persist:getNotFoundError(self.entityName, key);
             }
+            check self.setExpireIfCache(key, self.collectionName, key);
+
+            // Update the ttl for associations
+            if self.isCache() {
+                foreach RefMetadata refMetaData in self.refMetadata {
+                    string relatedRecordAssociationKey = refMetaData.refCollection;
+                    foreach string joinField in refMetaData.joinFields {
+                        relatedRecordAssociationKey
+                        = string `${relatedRecordAssociationKey}${KEY_SEPERATOR}${value[joinField].toString()}`;
+                    }
+                    relatedRecordAssociationKey
+                    = string `${relatedRecordAssociationKey}${KEY_SEPERATOR}${refMetaData.refMetaDataKey ?: ""}`;
+
+                    int ttlResult = check self.dbClient->ttl(relatedRecordAssociationKey);
+                    if ttlResult <= 0 {
+                        _ = check self.dbClient->sAdd(relatedRecordAssociationKey, [key]);
+                    }
+                    _ = check self.dbClient->expire(relatedRecordAssociationKey, self.maxAge);
+                }
+                foreach string associationField in associationFields {
+                    _ = value.remove(associationField);
+                }
+            }
+
             record {} valueToRecord = {};
             foreach string fieldKey in value.keys() {
                 // Convert the data type from 'any' to relevent type
@@ -587,8 +663,9 @@ public isolated client class RedisClient {
             map<any> value = check self.dbClient->hMGet(key, relationFields);
             self.logQuery(HMGET, {key: key, fieldNames: relationFields.toJsonString()});
             if self.isNoRecordFound(value) {
-                return error persist:Error(string `No '${entity}' found for the given key '${key}'`);
+                return persist:getNotFoundError(refMetaData.refCollection, key);
             }
+            check self.setExpireIfCache(key, refMetaData.refCollection, key);
 
             record {} valueToRecord = {};
             string fieldMetadataKeyPrefix = entity;
@@ -681,6 +758,8 @@ public isolated client class RedisClient {
                     return error persist:Error(sAdd.message(), sAdd);
                 }
 
+                check self.setExpireIfCache(setKey, self.collectionName, refRecordKey);
+
                 map<any> value = check self.dbClient->hMGet(refRecordKey, refMetadataValue.refFields);
                 self.logQuery(HMGET, {key: refRecordKey, fieldNames: refMetadataValue.refFields.toJsonString()});
                 if self.isNoRecordFound(value) {
@@ -691,6 +770,21 @@ public isolated client class RedisClient {
                     return e;
                 }
                 return error persist:Error(e.message(), e);
+            }
+        }
+    }
+
+    private isolated function setExpireIfCache(string expireKey, string collectionIfNotFound, string keyIfNotFound)
+    returns persist:Error|persist:NotFoundError? {
+        if self.isCache() {
+            boolean|redis:Error expire = self.dbClient->expire(expireKey, self.maxAge);
+            if expire is redis:Error {
+                return error persist:Error(expire.message(), expire);
+            } else {
+                self.logQuery(EXPIRE, expireKey);
+                if expire == false {
+                    return persist:getNotFoundError(collectionIfNotFound, keyIfNotFound);
+                }
             }
         }
     }
@@ -915,7 +1009,7 @@ public isolated client class RedisClient {
                 KEYS => {
                     info = string `Pattern : ${metadata}`;
                 }
-                REDISTYPE|SCARD|SMEMBERS => {
+                REDISTYPE|SCARD|SMEMBERS|EXPIRE => {
                     info = string `Key : ${metadata}`;
                 }
             }

--- a/ballerina/redis_metadata.bal
+++ b/ballerina/redis_metadata.bal
@@ -28,5 +28,6 @@ enum RedisDBOperation {
     DEL,
     SCARD,
     SADD,
-    SMEMBERS
+    SMEMBERS,
+    EXPIRE
 }

--- a/ballerina/tests/Config.toml
+++ b/ballerina/tests/Config.toml
@@ -1,2 +1,5 @@
-[redis]
+[connectionConfig]
 connection = "redis://localhost:6379"
+
+[cacheConfig]
+maxAge = -1

--- a/ballerina/tests/init-test.bal
+++ b/ballerina/tests/init-test.bal
@@ -17,11 +17,14 @@ import ballerina/test;
 import ballerina/time;
 import ballerinax/redis;
 
-configurable redis:ConnectionConfig & readonly redis = ?;
+configurable redis:ConnectionConfig & readonly connectionConfig = ?;
+configurable record {|
+    int maxAge;
+|} & readonly cacheConfig = ?;
 
 @test:BeforeSuite
 function initTests() returns error? {
-    redis:Client redisDbClient = check new (redis);
+    redis:Client redisDbClient = check new (connectionConfig);
     _ = check redisDbClient.close();
 }
 
@@ -837,6 +840,17 @@ Apartment apartment1 = {
     ownpersonId: 2
 };
 
+Apartment apartment2 = {
+    code: "B002",
+    city: "New Jursey",
+    state: "New Jursey",
+    country: "USA",
+    postalCode: "10010",
+    'type: "Office",
+    soldpersonId: 1,
+    ownpersonId: 2
+};
+
 ApartmentUpdate apartmentUpdate = {
     postalCode: "00002"
 };
@@ -865,4 +879,70 @@ PersonWithAssociations person1WithAssociations = {
             code: "B002"
         }
     ]
+};
+
+PersonWithAssoc person1WithAssoc = {
+    id: 1,
+    name: "Jane",
+    soldBuildings: [{code: "B001"}]
+};
+
+PersonWithAssoc person1WithoutAssoc = {
+    id: 1,
+    name: "Jane",
+    soldBuildings: []
+};
+
+PersonWithAssoc[] peopleWithAssoc = [
+    {
+        id: 1,
+        name: "Jane",
+        soldBuildings: [{code: "B001"}]
+    },
+    {
+        id: 2,
+        name: "Mike",
+        soldBuildings: []
+    }
+];
+
+ApartmentWithAssoc[] apartmentsWithAssoc = [
+    {
+        code: "B001",
+        city: "New York",
+        state: "New York",
+        soldPerson: {id: 1, name: "Jane"}
+    }
+];
+
+ApartmentWithAssoc apartment1WithPerson = {
+    code: "B001",
+    city: "New York",
+    state: "New York",
+    soldPerson: {id: 1, name: "Jane"}
+};
+
+ApartmentWithAssoc apartment1WithPersonUpdated = {
+    code: "B001",
+    city: "New Jursey",
+    state: "New York",
+    soldPerson: {id: 1, name: "Mike"}
+};
+
+PersonWithAssoc person1OnlyPerson = {
+    id: 1,
+    name: "Jane",
+    soldBuildings: []
+};
+
+PersonWithAssoc person1WithAssocUpdated = {
+    id: 1,
+    name: "Mike",
+    soldBuildings: []
+};
+
+PersonWithAssoc person1WithAssocUpdated2 = {
+    id: 1,
+    name: "Mike",
+    soldBuildings: [{code: "B001"}]
 };

--- a/ballerina/tests/redis-caching-tests.bal
+++ b/ballerina/tests/redis-caching-tests.bal
@@ -1,0 +1,239 @@
+// Copyright (c) 2024 WSO2 LLC. (http://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+import ballerina/test;
+import ballerina/lang.runtime;
+import ballerina/persist;
+
+@test:Config {
+    groups: ["cache", "redis"],
+    dependsOn: []
+}
+function redisAllTest() returns error? {
+    RedisCacheClient cacheClient = check new ();
+
+    int[] ids = check cacheClient->/people.post([person1]);
+    test:assertEquals(ids, [person1.id]);
+    int[] ids2 = check cacheClient->/people.post([person2]);
+    test:assertEquals(ids2, [person2.id]);
+
+    string[] apartmentCodes = check cacheClient->/apartments.post([apartment1]);
+    test:assertEquals(apartmentCodes, [apartment1.code]);
+
+    PersonWithAssoc personRetrieved = check cacheClient->/people/[person1.id];
+    test:assertEquals(personRetrieved, person1WithAssoc);
+
+    ApartmentWithAssoc apartmentRetrieved = check cacheClient->/apartments/[apartment1.code];
+    test:assertEquals(apartmentRetrieved, apartment1WithPerson);
+
+    runtime:sleep(4);
+    check cacheClient.close();
+}
+
+@test:Config {
+    groups: ["cache", "redis"],
+    dependsOn: [redisAllTest]
+}
+function redisEmployeeOnlyTest() returns error? {
+    RedisCacheClient cacheClient = check new ();
+
+    int[] ids = check cacheClient->/people.post([person1]);
+    test:assertEquals(ids, [person1.id]);
+    int[] ids2 = check cacheClient->/people.post([person2]);
+    test:assertEquals(ids2, [person2.id]);
+
+    string[] apartmentCodes = check cacheClient->/apartments.post([apartment1]);
+    test:assertEquals(apartmentCodes, [apartment1.code]);
+
+    runtime:sleep(1);
+    _ = check cacheClient->/people/[person1.id].put({name: "Mike"});
+    _ = check cacheClient->/people/[person2.id].put({name: "Akela"});
+    runtime:sleep(3);
+
+    PersonWithAssoc personRetrieved = check cacheClient->/people/[person1.id];
+    test:assertEquals(personRetrieved, person1WithAssocUpdated);
+
+    runtime:sleep(4);
+    check cacheClient.close();
+}
+
+@test:Config {
+    groups: ["cache", "redis"],
+    dependsOn: [redisEmployeeOnlyTest]
+}
+function redisDependentOnlyTest() returns error? {
+    RedisCacheClient cacheClient = check new ();
+
+    int[] ids = check cacheClient->/people.post([person1]);
+    test:assertEquals(ids, [person1.id]);
+    int[] ids2 = check cacheClient->/people.post([person2]);
+    test:assertEquals(ids2, [person2.id]);
+
+    string[] apartmentCodes = check cacheClient->/apartments.post([apartment1]);
+    test:assertEquals(apartmentCodes, [apartment1.code]);
+
+    runtime:sleep(1);
+    _ = check cacheClient->/apartments/[apartment1.code].put({city: "New Jursey"});
+    runtime:sleep(3);
+
+    ApartmentWithAssoc|persist:Error apartmentRetrieved = cacheClient->/apartments/[apartment1.code];
+    test:assertTrue(apartmentRetrieved is persist:NotFoundError, "Should return a `persist:NotFoundError`");
+
+    runtime:sleep(4);
+    check cacheClient.close();
+}
+
+@test:Config {
+    groups: ["cache", "redis"],
+    dependsOn: [redisDependentOnlyTest]
+}
+function redisEmployeeAndDependentTest() returns error? {
+    RedisCacheClient cacheClient = check new ();
+
+    int[] ids = check cacheClient->/people.post([person1]);
+    test:assertEquals(ids, [person1.id]);
+    int[] ids2 = check cacheClient->/people.post([person2]);
+    test:assertEquals(ids2, [person2.id]);
+
+    string[] apartmentCodes = check cacheClient->/apartments.post([apartment1]);
+    test:assertEquals(apartmentCodes, [apartment1.code]);
+
+    runtime:sleep(1);
+    _ = check cacheClient->/people/[person1.id].put({name: "Mike"});
+    _ = check cacheClient->/people/[person2.id].put({name: "Akela"});
+    _ = check cacheClient->/apartments/[apartment1.code].put({city: "New Jursey"});
+    runtime:sleep(3);
+
+    PersonWithAssoc personRetrieved = check cacheClient->/people/[person1.id];
+    test:assertEquals(personRetrieved, person1WithAssocUpdated2);
+
+    ApartmentWithAssoc apartmentRetrieved = check cacheClient->/apartments/[apartment1.code];
+    test:assertEquals(apartmentRetrieved, apartment1WithPersonUpdated);
+
+    runtime:sleep(4);
+    check cacheClient.close();
+}
+
+@test:Config {
+    groups: ["cache", "redis"],
+    dependsOn: [redisEmployeeAndDependentTest]
+}
+function redisDependentAndSetTest() returns error? {
+    RedisCacheClient cacheClient = check new ();
+
+    int[] ids = check cacheClient->/people.post([person1]);
+    test:assertEquals(ids, [person1.id]);
+    int[] ids2 = check cacheClient->/people.post([person2]);
+    test:assertEquals(ids2, [person2.id]);
+
+    runtime:sleep(1);
+    string[] apartmentCodes = check cacheClient->/apartments.post([apartment1]);
+    test:assertEquals(apartmentCodes, [apartment1.code]);
+    runtime:sleep(3);
+
+    ApartmentWithAssoc|persist:Error apartmentRetrieved = cacheClient->/apartments/[apartment1.code];
+    test:assertTrue(apartmentRetrieved is persist:NotFoundError, "Should return a `persist:NotFoundError`");
+
+    runtime:sleep(4);
+    check cacheClient.close();
+}
+
+@test:Config {
+    groups: ["cache", "redis"],
+    dependsOn: [redisDependentAndSetTest]
+}
+function redisEmployeeAndSetTest() returns error? {
+    RedisCacheClient cacheClient = check new ();
+
+    int[] ids = check cacheClient->/people.post([person1]);
+    test:assertEquals(ids, [person1.id]);
+    int[] ids2 = check cacheClient->/people.post([person2]);
+    test:assertEquals(ids2, [person2.id]);
+
+    runtime:sleep(2);
+    string[] apartmentCodes = check cacheClient->/apartments.post([apartment2]);
+    test:assertEquals(apartmentCodes, [apartment2.code]);
+    runtime:sleep(1);
+    Person personRetrieved = check cacheClient->/people/[person1.id];
+    test:assertEquals(personRetrieved, person1);
+    apartmentCodes = check cacheClient->/apartments.post([apartment1]);
+    test:assertEquals(apartmentCodes, [apartment1.code]);
+    runtime:sleep(3);
+
+    PersonWithAssoc person = check cacheClient->/people/[person1.id];
+    test:assertEquals(person, person1WithAssoc);
+
+    runtime:sleep(4);
+    check cacheClient.close();
+}
+
+@test:Config {
+    groups: ["cache", "redis"],
+    dependsOn: [redisEmployeeAndSetTest]
+}
+function redisMiscTest() returns error? {
+    RedisCacheClient cacheClient = check new ();
+
+    int[] ids = check cacheClient->/people.post([person1]);
+    test:assertEquals(ids, [person1.id]);
+    int[] ids2 = check cacheClient->/people.post([person2]);
+    test:assertEquals(ids2, [person2.id]);
+
+    string[] apartmentCodes = check cacheClient->/apartments.post([apartment1]);
+    test:assertEquals(apartmentCodes, [apartment1.code]);
+
+    stream<PersonWithAssoc, persist:Error?> peopleStream = cacheClient->/people;
+    PersonWithAssoc[] people = check from PersonWithAssoc person2 in peopleStream
+        order by person2.id ascending
+        select person2;
+    test:assertEquals(people, peopleWithAssoc);
+
+    stream<ApartmentWithAssoc, persist:Error?> apartmentsStream = cacheClient->/apartments;
+    ApartmentWithAssoc[] apartments = check from ApartmentWithAssoc apartment2 in apartmentsStream
+        order by apartment2.code ascending
+        select apartment2;
+    test:assertEquals(apartments, apartmentsWithAssoc);
+
+    _ = check cacheClient->/apartments/[apartment1.code].delete();
+    Apartment|persist:Error apartment1Retreived = cacheClient->/apartments/[apartment1.code];
+    test:assertTrue(apartment1Retreived is persist:NotFoundError, "Should return a `persist:NotFoundError`");
+    PersonWithAssoc|persist:Error person1WithAssoc = cacheClient->/people/[person1.id];
+    test:assertEquals(person1WithAssoc, person1WithoutAssoc);
+
+    _ = check cacheClient->/people/[person1.id].delete();
+    Person|persist:Error person1Retreived = cacheClient->/people/[person1.id];
+    test:assertTrue(person1Retreived is persist:NotFoundError, "Should return a `persist:NotFoundError`");
+
+    runtime:sleep(4);
+    check cacheClient.close();
+}
+
+type PersonWithAssoc record {|
+    readonly int id;
+    string name;
+    record {|
+        string code;
+    |}[] soldBuildings;
+|};
+
+type ApartmentWithAssoc record {|
+    string code;
+    string city;
+    string state;
+    record {|
+        int id;
+        string name;
+    |} soldPerson;
+|};

--- a/ballerina/tests/redis_rainier_generated_client.bal
+++ b/ballerina/tests/redis_rainier_generated_client.bal
@@ -313,17 +313,17 @@ public isolated client class RedisRainierClient {
     };
 
     public isolated function init() returns persist:Error? {
-        redis:Client|error dbClient = new (redis);
+        redis:Client|error dbClient = new (connectionConfig);
         if dbClient is error {
             return <persist:Error>error(dbClient.message());
         }
         self.dbClient = dbClient;
         self.persistClients = {
-            [EMPLOYEE]: check new (dbClient, self.metadata.get(EMPLOYEE)),
-            [WORKSPACE]: check new (dbClient, self.metadata.get(WORKSPACE)),
-            [BUILDING]: check new (dbClient, self.metadata.get(BUILDING)),
-            [DEPARTMENT]: check new (dbClient, self.metadata.get(DEPARTMENT)),
-            [ORDER_ITEM]: check new (dbClient, self.metadata.get(ORDER_ITEM))
+            [EMPLOYEE]: check new (dbClient, self.metadata.get(EMPLOYEE), cacheConfig.maxAge),
+            [WORKSPACE]: check new (dbClient, self.metadata.get(WORKSPACE), cacheConfig.maxAge),
+            [BUILDING]: check new (dbClient, self.metadata.get(BUILDING), cacheConfig.maxAge),
+            [DEPARTMENT]: check new (dbClient, self.metadata.get(DEPARTMENT), cacheConfig.maxAge),
+            [ORDER_ITEM]: check new (dbClient, self.metadata.get(ORDER_ITEM), cacheConfig.maxAge)
         };
     }
 

--- a/ballerina/tests/redis_test_cache_client.bal
+++ b/ballerina/tests/redis_test_cache_client.bal
@@ -20,10 +20,12 @@ import ballerina/jballerina.java;
 import ballerina/persist;
 import ballerinax/redis;
 
+final redis:ConnectionConfig & readonly redisCache = {connection: "redis://localhost:6378"};
+
 const PERSON = "people";
 const APARTMENT = "apartments";
 
-public isolated client class RedisManyAssociationsClient {
+public isolated client class RedisCacheClient {
     *persist:AbstractPersistClient;
 
     private final redis:Client dbClient;
@@ -85,15 +87,15 @@ public isolated client class RedisManyAssociationsClient {
         }
     };
 
-    public isolated function init() returns persist:Error?|error {
+    public isolated function init() returns persist:Error? {
         redis:Client|error dbClient = new (connectionConfig);
         if dbClient is error {
             return <persist:Error>error(dbClient.message());
         }
         self.dbClient = dbClient;
         self.persistClients = {
-            [PERSON]: check new (dbClient, self.metadata.get(PERSON), cacheConfig.maxAge),
-            [APARTMENT]: check new (dbClient, self.metadata.get(APARTMENT), cacheConfig.maxAge)
+            [PERSON]: check new (dbClient, self.metadata.get(PERSON), 4),
+            [APARTMENT]: check new (dbClient, self.metadata.get(APARTMENT), 4)
         };
     }
 

--- a/ballerina/tests/redis_test_entities_generated_client.bal
+++ b/ballerina/tests/redis_test_entities_generated_client.bal
@@ -272,7 +272,7 @@ public isolated client class RedisTestEntitiesClient {
         }
     };
 
-    public isolated function init() returns persist:Error?|error {
+    public isolated function init() returns persist:Error? {
         redis:Client|error dbClient = new (connectionConfig);
         if dbClient is error {
             return <persist:Error>error(dbClient.message());

--- a/ballerina/tests/redis_test_entities_generated_client.bal
+++ b/ballerina/tests/redis_test_entities_generated_client.bal
@@ -272,21 +272,22 @@ public isolated client class RedisTestEntitiesClient {
         }
     };
 
-    public isolated function init() returns persist:Error? {
-        redis:Client|error dbClient = new (redis);
+    public isolated function init() returns persist:Error?|error {
+        redis:Client|error dbClient = new (connectionConfig);
         if dbClient is error {
             return <persist:Error>error(dbClient.message());
         }
         self.dbClient = dbClient;
         self.persistClients = {
-            [ALL_TYPES]: check new (dbClient, self.metadata.get(ALL_TYPES)),
-            [STRING_ID_RECORD]: check new (dbClient, self.metadata.get(STRING_ID_RECORD)),
-            [INT_ID_RECORD]: check new (dbClient, self.metadata.get(INT_ID_RECORD)),
-            [FLOAT_ID_RECORD]: check new (dbClient, self.metadata.get(FLOAT_ID_RECORD)),
-            [DECIMAL_ID_RECORD]: check new (dbClient, self.metadata.get(DECIMAL_ID_RECORD)),
-            [BOOLEAN_ID_RECORD]: check new (dbClient, self.metadata.get(BOOLEAN_ID_RECORD)),
-            [COMPOSITE_ASSOCIATION_RECORD]: check new (dbClient, self.metadata.get(COMPOSITE_ASSOCIATION_RECORD)),
-            [ALL_TYPES_ID_RECORD]: check new (dbClient, self.metadata.get(ALL_TYPES_ID_RECORD))
+            [ALL_TYPES]: check new (dbClient, self.metadata.get(ALL_TYPES), cacheConfig.maxAge),
+            [STRING_ID_RECORD]: check new (dbClient, self.metadata.get(STRING_ID_RECORD), cacheConfig.maxAge),
+            [INT_ID_RECORD]: check new (dbClient, self.metadata.get(INT_ID_RECORD), cacheConfig.maxAge),
+            [FLOAT_ID_RECORD]: check new (dbClient, self.metadata.get(FLOAT_ID_RECORD), cacheConfig.maxAge),
+            [DECIMAL_ID_RECORD]: check new (dbClient, self.metadata.get(DECIMAL_ID_RECORD), cacheConfig.maxAge),
+            [BOOLEAN_ID_RECORD]: check new (dbClient, self.metadata.get(BOOLEAN_ID_RECORD), cacheConfig.maxAge),
+            [COMPOSITE_ASSOCIATION_RECORD]: check new (dbClient, self.metadata.get(COMPOSITE_ASSOCIATION_RECORD), 
+            cacheConfig.maxAge),
+            [ALL_TYPES_ID_RECORD]: check new (dbClient, self.metadata.get(ALL_TYPES_ID_RECORD), cacheConfig.maxAge)
         };
     }
 

--- a/ballerina/tests/redis_test_multiple_associations_client.bal
+++ b/ballerina/tests/redis_test_multiple_associations_client.bal
@@ -85,7 +85,7 @@ public isolated client class RedisManyAssociationsClient {
         }
     };
 
-    public isolated function init() returns persist:Error?|error {
+    public isolated function init() returns persist:Error? {
         redis:Client|error dbClient = new (connectionConfig);
         if dbClient is error {
             return <persist:Error>error(dbClient.message());


### PR DESCRIPTION
## Purpose
To support project-level caching for Redis DB in `bal persist`

## Examples

## Checklist
- [ ] Linked to an issue
- [ ] Updated the specification
- [ ] Updated the changelog
- [ ] Added tests
- [ ] Checked native-image compatibility
